### PR TITLE
Fixing timezone format

### DIFF
--- a/alert/rule/structs.go
+++ b/alert/rule/structs.go
@@ -50,18 +50,12 @@ type NotificationConfig struct {
 	LastSentTs         int      `json:"last_send_ts"`
 	Type               string   `json:"type"`
 	TemplateId         string   `json:"templateId,omitempty"`
-	Timezone           Timezone `json:"timezone"`
+	Timezone           string   `json:"timezone"`
 	DayOfMonth         int      `json:"dayOfMonth"`
 	RruleSchedule      string   `json:"rruleSchedule"`
 	FrequencyFromRrule string   `json:"frequencyFromRRule"`
 	HourOfDay          int      `json:"hourOfDay"`
 	DaysOfWeek         []Day    `json:"daysOfWeek"`
-}
-
-type Timezone struct {
-	Id string `json:"id"`
-	// TODO(gfreeman): add the rules when the data structure is known.
-	//Rules interface{} `json:"rules"`
 }
 
 type Day struct {


### PR DESCRIPTION
Cannot POST alert rules because of the timezone format expected.

(object vs string)

(+ it is unused because only the schedule seems to be working)